### PR TITLE
Run framework CI tests with swift test instead of skip test

### DIFF
--- a/.github/workflows/skip-framework.yml
+++ b/.github/workflows/skip-framework.yml
@@ -196,23 +196,26 @@ jobs:
         if: ${{ inputs.run-android-native-build == 'true' || (steps.setup.outputs.skip-fuse == 'true' && inputs.run-android-native-build != 'false') }}
         run: skip android build --verbose
 
-      - name: Export project
-        if: ${{ inputs.run-export == true }}
-        run: |
-          rm -rf .build .swiftpm Package.resolved
-          skip export -v -d skip-export --show-tree --summary-file=$GITHUB_STEP_SUMMARY
-
       - name: Test Local Swift & Robolectric
         if: ${{ inputs.run-local-tests == true && !startsWith(github.ref, 'refs/tags/') }}
         # workaround for Swift 5.9 error: "error: invalid tool type in 'tools' map" (https://github.com/swiftlang/swift-package-manager/issues/6755)
         run: |
           rm -rf .build .swiftpm Package.resolved
-          if [ ${RUNNER_OS} == 'Linux' ]; then
+          swift test
+
+          # disabling skip test for now because it doesn't execute XCTestCase
+          #if [ ${RUNNER_OS} == 'Linux' ]; then
             # skip test does not yet work on Linux ("SkipDrive not linked")
-            swift test
-          else
-            skip test --verbose
-          fi
+            #swift test
+          #else
+            #skip test --verbose
+          #fi
+
+      - name: Export project
+        if: ${{ inputs.run-export == true }}
+        run: |
+          rm -rf .build .swiftpm Package.resolved
+          skip export -v -d skip-export --show-tree --summary-file=$GITHUB_STEP_SUMMARY
 
       - name: Test iOS (connected)
         if: ${{ runner.os == 'macOS' && inputs.run-ios-tests == true && !startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
Switch the local testing in `skip-framework.yml` to use `swift test` instead of `skip test` due to https://github.com/skiptools/skipstone/issues/233